### PR TITLE
[wip] #8: resolve message overflow

### DIFF
--- a/OutlookMatters.Core.Test/Mattermost/HttpImpl/HttpSessionTest.cs
+++ b/OutlookMatters.Core.Test/Mattermost/HttpImpl/HttpSessionTest.cs
@@ -23,6 +23,9 @@ namespace Test.OutlookMatters.Core.Mattermost.HttpImpl
             const string jsonPost =
                 @"{""id"":"""",""channel_id"":""channelId"",""message"":""Hello World!"",""user_id"":""userId"",""root_id"":""""}";
             var httpRequest = new Mock<IHttpRequest>();
+            var httpResponse = new Mock<IHttpResponse>();
+            httpResponse.Setup(x => x.GetPayload()).Returns(string.Empty);
+            httpRequest.Setup(x => x.Post(It.IsAny<string>())).Returns(httpResponse.Object);
             var classUnderTest = SetupUserSessionForCreatingPosts(httpRequest);
 
             classUnderTest.CreatePost(ChannelId, Message);
@@ -90,6 +93,9 @@ namespace Test.OutlookMatters.Core.Mattermost.HttpImpl
             const string jsonPost =
                 @"{""id"":"""",""channel_id"":""channelId"",""message"":""Hello World!"",""user_id"":""userId"",""root_id"":""rootId""}";
             var httpRequest = new Mock<IHttpRequest>();
+            var httpResponse = new Mock<IHttpResponse>();
+            httpResponse.Setup(x => x.GetPayload()).Returns(string.Empty);
+            httpRequest.Setup(x => x.Post(It.IsAny<string>())).Returns(httpResponse.Object);
             var classUnderTest = SetupUserSessionForCreatingPosts(httpRequest);
 
             classUnderTest.CreatePost(ChannelId, Message, RootId);
@@ -130,6 +136,7 @@ namespace Test.OutlookMatters.Core.Mattermost.HttpImpl
         {
             var httpRequest = new Mock<IHttpRequest>();
             var httpResponse = new Mock<IHttpResponse>();
+            httpResponse.Setup(x => x.GetPayload()).Returns(string.Empty);
             httpRequest.Setup(x => x.Post(It.IsAny<string>())).Returns(httpResponse.Object);
             var classUnderTest = SetupUserSessionForCreatingPosts(httpRequest);
 

--- a/OutlookMatters.Core/ContextMenu/MailItemContextMenuEntry.cs
+++ b/OutlookMatters.Core/ContextMenu/MailItemContextMenuEntry.cs
@@ -148,8 +148,10 @@ namespace OutlookMatters.Core.ContextMenu
                 var postId = _rootPostIdProvider.Get();
                 var rootPost = _session.GetRootPost(postId);
                 var rootId = rootPost.id;
-
-                _session.CreatePost(rootPost.channel_id, messageParts[0], rootId);
+                foreach (var messagePart in messageParts)
+                {
+                    _session.CreatePost(rootPost.channel_id, messagePart, rootId);
+                }
             }
             catch (UserAbortException)
             {

--- a/OutlookMatters.Core/ContextMenu/MailItemContextMenuEntry.cs
+++ b/OutlookMatters.Core/ContextMenu/MailItemContextMenuEntry.cs
@@ -166,17 +166,17 @@ namespace OutlookMatters.Core.ContextMenu
             }
         }
 
-        private List<string> FormatMessage()
+        private IEnumerable<string> FormatMessage()
         {
             var mail = _explorer.QuerySelectedMailItem();
             var message = ":email: From: " + mail.SenderName + "\n";
             message += ":email: Subject: " + mail.Subject + "\n";
             message += mail.Body;
 
-            return GenerateCompleteMessage(message);
+            return SplitMessageIntoParts(message);
         }
 
-        private List<string> GenerateCompleteMessage(string message)
+        private IEnumerable<string> SplitMessageIntoParts(string message)
         {
             var messageParts = new List<string>();
             
@@ -185,11 +185,15 @@ namespace OutlookMatters.Core.ContextMenu
                 if (message.Length > MAX_MESSAGE_LENGTH)
                 {
                     var messageSlice = message.Substring(0, MAX_MESSAGE_LENGTH);
-                    var positionOfLastSpace = messageSlice.LastIndexOf(" ");
-                    var slicedMessagePart = message.Substring(0, positionOfLastSpace);
+                    var cuttingIndex = messageSlice.LastIndexOf(" ");
+                    if (cuttingIndex <= 0)
+                    {
+                        cuttingIndex = MAX_MESSAGE_LENGTH - 1;
+                    }
+                    var slicedMessagePart = message.Substring(0, cuttingIndex);
                     messageParts.Add(slicedMessagePart);
-                    var leftOverLength = message.Length - positionOfLastSpace;
-                    message = message.Substring(positionOfLastSpace, leftOverLength);
+                    var leftOverLength = message.Length - cuttingIndex;
+                    message = message.Substring(cuttingIndex, leftOverLength);
                 }
                 else
                 {

--- a/OutlookMatters.Core/Mattermost/HttpImpl/HttpSession.cs
+++ b/OutlookMatters.Core/Mattermost/HttpImpl/HttpSession.cs
@@ -20,7 +20,7 @@ namespace OutlookMatters.Core.Mattermost.HttpImpl
             _httpClient = httpClient;
         }
 
-        public void CreatePost(string channelId, string message, string rootId = "")
+        public Payload CreatePost(string channelId, string message, string rootId = "")
         {
             try
             {
@@ -33,11 +33,13 @@ namespace OutlookMatters.Core.Mattermost.HttpImpl
                     root_id = rootId
                 };
                 var postUrl = PostUrl(channelId);
-                using (_httpClient.Request(postUrl)
+                using (var response = _httpClient.Request(postUrl)
                     .WithContentType("text/json")
                     .WithHeader("Authorization", "Bearer " + _token)
                     .Post(JsonConvert.SerializeObject(post)))
                 {
+                    var payload = response.GetPayload();
+                    return JsonConvert.DeserializeObject<Payload>(payload);
                 }
             }
             catch (HttpException hex)

--- a/OutlookMatters.Core/Mattermost/Interface/ISession.cs
+++ b/OutlookMatters.Core/Mattermost/Interface/ISession.cs
@@ -2,7 +2,7 @@
 {
     public interface ISession
     {
-        void CreatePost(string channelId, string message, string rootId = "");
+        Payload CreatePost(string channelId, string message, string rootId = "");
         Post GetRootPost(string postId);
         ChannelList FetchChannelList();
     }

--- a/OutlookMatters.Core/Mattermost/Interface/Payload.cs
+++ b/OutlookMatters.Core/Mattermost/Interface/Payload.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace OutlookMatters.Core.Mattermost.Interface
 {

--- a/OutlookMatters.Core/Mattermost/Interface/Payload.cs
+++ b/OutlookMatters.Core/Mattermost/Interface/Payload.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace OutlookMatters.Core.Mattermost.Interface
+{
+    public class Payload
+    {
+        [JsonProperty("id")]
+        public string PostId { get; set; } 
+    }
+}

--- a/OutlookMatters.Core/Mattermost/Utils/TransientSession.cs
+++ b/OutlookMatters.Core/Mattermost/Utils/TransientSession.cs
@@ -40,9 +40,9 @@ namespace OutlookMatters.Core.Mattermost.Utils
             }
         }
 
-        public void CreatePost(string channelId, string message, string rootId = "")
+        public Payload CreatePost(string channelId, string message, string rootId = "")
         {
-            Session.CreatePost(channelId, message, rootId);
+            return Session.CreatePost(channelId, message, rootId);
         }
 
         public Post GetRootPost(string postId)

--- a/OutlookMatters.Core/OutlookMatters.Core.csproj
+++ b/OutlookMatters.Core/OutlookMatters.Core.csproj
@@ -95,6 +95,7 @@
     <Compile Include="Mattermost\Interface\ChannelType.cs" />
     <Compile Include="Mattermost\Interface\Error.cs" />
     <Compile Include="Mattermost\Interface\Login.cs" />
+    <Compile Include="Mattermost\Interface\Payload.cs" />
     <Compile Include="Mattermost\Interface\Post.cs" />
     <Compile Include="Mattermost\Interface\Thread.cs" />
     <Compile Include="Mattermost\Interface\User.cs" />


### PR DESCRIPTION
This pull request is work in progress, don't merge yet. This pull request resolves issue #8. 
Mattermost does not accept messages, which exceed 4000 chars, if this case happens, the application splits the message into smaller parts and posts all of them. Work packages to do before merging:
- [ ] Exploratory test for this feature
- [ ] Add more unit tests for every case

